### PR TITLE
fix(binaries): Correct set IFS for multiple binaries

### DIFF
--- a/examples/full_build.yaml
+++ b/examples/full_build.yaml
@@ -19,6 +19,7 @@ repositories:
 binaries:
   github:
     - remotemobprogramming/mob=linux_amd64
+    - derailed/k9s=Linux_amd64
   google:
     - google-cloud-cli
 requirements:

--- a/template.d/13_binaries
+++ b/template.d/13_binaries
@@ -1,7 +1,8 @@
 ## binaries
 RUN if [ -n "${BINARIES}" ]; then \
       IFS=';' && \
-      for BINARY in ${BINARIES[@]}; do declare -u BINARY_REPO="${BINARY}" && BINARY_URI=$(eval "echo \$BINARIES_${BINARY_REPO}_URI") && BINARY_PACKAGES=$(eval "echo \$BINARIES_${BINARY_REPO}") && \
+      for BINARY in ${BINARIES[@]}; do IFS='' && declare -u BINARY_REPO="${BINARY}" && BINARY_URI=$(eval "echo \$BINARIES_${BINARY_REPO}_URI") && BINARY_PACKAGES=$(eval "echo \$BINARIES_${BINARY_REPO}") && \
+      IFS=';' && \
       if [ "${BINARY_REPO}" = "GITHUB" ]; then for BINARY_PACKAGE in ${BINARY_PACKAGES}; do BINARY_PACKAGE_URI=$(echo "${BINARY_URI}/${BINARY_PACKAGE}" | awk -F '=' '{ if (!$3) {version="/latest"}; printf("%s/releases%s", $1, version)}')  && \
       BINARY_PACKAGE_VERSION=$(echo "${BINARY_PACKAGE}" | awk -F '=' '{print $3".*"$2".tar.gz"}') && \
       BINARY_PACKAGE_URL=$(curl -fsSL "${BINARY_PACKAGE_URI}" | grep -Po '"browser_download_url": "\K.*?(?=\")' | grep -P "${BINARY_PACKAGE_VERSION}") && \


### PR DESCRIPTION
With correctly set IFS in the build step for binaries, more than one binary from Github, Google, etc. can now be loaded into the DMC again.