### PR TITLE
add "--break-system-packages" to pip commands

### DIFF
--- a/template.d/21_requirements
+++ b/template.d/21_requirements
@@ -13,12 +13,12 @@ RUN if [ -n "${REQUIREMENTS}" ]; then \
         if [ "${REQ}" = "PIP" ]; then \
           for REQUIREMENT_REQ in ${REQUIREMENTS_PIP_PACKAGES[@]}; \
           do \
-            pip3 install --no-cache-dir "${REQUIREMENT_REQ//=/==}"; \
+            pip3 install --no-cache-dir --break-system-packages "${REQUIREMENT_REQ//=/==}"; \
           done && \
           \
           for REQUIREMENT_REQ in ${REQUIREMENTS_PIP_REQUIREMENTS[@]}; \
           do \
-            pip3 install --no-cache-dir -r "${REQUIREMENT_REQ}"; \
+            pip3 install --no-cache-dir --break-system-packages -r "${REQUIREMENT_REQ}"; \
           done; \
         fi && \
         \


### PR DESCRIPTION
add --break-system-packages to pip executions as we don't care about this in a disposable container.

This should fix the issue described in #128