### PR TITLE
install awscli over pip

### DIFF
--- a/examples/full_build.yaml
+++ b/examples/full_build.yaml
@@ -6,7 +6,6 @@ packages:
   - consul
   - docker-ce
   - azure-cli
-  - awscli
   - telnet
 repositories:
   docker: {}
@@ -29,6 +28,7 @@ requirements:
       - telekom_mms.icinga_director
   pip:
     packages:
+      - awscli
       - awsume
       - ansible
     requirements:


### PR DESCRIPTION
awscli not available over wakemeops repo anymore, https://github.com/telekom-mms/docker-management-container/issues/119